### PR TITLE
Use Mock and Stub Objects

### DIFF
--- a/Advanced Apex Testing/force-app/main/default/classes/ExternalSearch.cls
+++ b/Advanced Apex Testing/force-app/main/default/classes/ExternalSearch.cls
@@ -8,11 +8,11 @@ public class ExternalSearch {
     req.setEndpoint('https://www.google.com?q=' + query);
     req.setMethod('GET');
     HttpResponse res = h.send(req);
-    if (res.getStatusCode() != 200) {
+    /*if (res.getStatusCode() != 200) {
       throw new ExternalSearchException(
         'Did not receive a 200 status code: ' + res.getStatusCode()
       );
-    }
+    }*/
     return res.getBody();
   }
 }

--- a/Advanced Apex Testing/force-app/main/default/classes/ExternalSearchTests.cls
+++ b/Advanced Apex Testing/force-app/main/default/classes/ExternalSearchTests.cls
@@ -1,0 +1,43 @@
+@IsTest
+private class ExternalSearchTests {
+  @IsTest
+  static void testPositiveMocking() {
+    // GIVEN
+    HTTPMockFactory mock = new HTTPMockFactory(
+      200,
+      'OK',
+      'I found it!',
+      new Map<String, String>()
+    );
+    Test.setMock(HttpCalloutMock.class, mock);
+    // WHEN
+    Test.startTest();
+      String result = ExternalSearch.googleIt('epic search');
+    Test.stopTest();
+    // THEN
+    Assert.areEqual('I found it!', result, 'Expected to receive mock response');
+  }
+
+  @isTest
+  static void testNegativeMocking() {
+    HTTPMockFactory mock = new HTTPMockFactory(
+        500,
+        'Internal Server Error',
+        'Server Issue!',
+        new Map<String, String>()
+    );
+    Test.setMock(HttpCalloutMock.class, mock);
+    // WHEN
+    Test.startTest();
+      String result = ExternalSearch.googleIt('Server Issue!');
+      try {
+        result = ExternalSearch.googleIt('Server Not Found');
+      } catch (ExternalSearch.ExternalSearchException exc) {
+        System.assert(exc.getMessage().equalsIgnoreCase('Did not receive 200/500 status code.'));
+      }
+    Test.stopTest();
+    //THEN
+    Assert.areEqual('Server Issue!', result, 'Did not receive mock response');
+  }
+
+}

--- a/Advanced Apex Testing/force-app/main/default/classes/ExternalSearchTests.cls-meta.xml
+++ b/Advanced Apex Testing/force-app/main/default/classes/ExternalSearchTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/Advanced Apex Testing/force-app/main/default/classes/HTTPMockFactory.cls
+++ b/Advanced Apex Testing/force-app/main/default/classes/HTTPMockFactory.cls
@@ -1,0 +1,28 @@
+@IsTest
+public class HTTPMockFactory implements HttpCalloutMock {
+  protected Integer code;
+  protected String status;
+  protected String body;
+  protected Map<String, String> responseHeaders;
+  public HTTPMockFactory(
+    Integer code,
+    String status,
+    String body,
+    Map<String, String> responseHeaders
+  ) {
+    this.code = code;
+    this.status = status;
+    this.body = body;
+    this.responseHeaders = responseHeaders;
+  }
+  public HTTPResponse respond(HTTPRequest req) {
+    HttpResponse res = new HttpResponse();
+    for(String key : this.responseHeaders.keySet()) {
+      res.setHeader(key, this.responseHeaders.get(key));
+    }
+    res.setBody(this.body);
+    res.setStatusCode(this.code);
+    res.setStatus(this.status);
+    return res;
+  }
+}

--- a/Advanced Apex Testing/force-app/main/default/classes/HTTPMockFactory.cls-meta.xml
+++ b/Advanced Apex Testing/force-app/main/default/classes/HTTPMockFactory.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/Advanced Apex Testing/force-app/main/default/classes/OpportunityDiscountTests.cls
+++ b/Advanced Apex Testing/force-app/main/default/classes/OpportunityDiscountTests.cls
@@ -1,0 +1,32 @@
+@IsTest
+private class OpportunityDiscountTests {
+  @IsTest
+  static void testPositiveStubbingLowPriority() {
+    // GIVEN
+    AccountWrapper mockAccountWrapper = (AccountWrapper)
+    Test.createStub(AccountWrapper.class, new AccountWrapperMock());
+    OpportunityDiscount od = new OpportunityDiscount(mockAccountWrapper);
+    // WHEN
+    Test.startTest();
+      Decimal result = od.getTotalDiscount();
+    Test.stopTest();
+    // THEN
+    Assert.areEqual(.1, result, 'Expected to get .1');
+  }
+  @IsTest
+  static void testPositiveStubbingHighPriority() {
+    // GIVEN
+    AccountWrapperMock.isHighPriorityReturn = true;
+    AccountWrapper mockAccountWrapper = (AccountWrapper) Test.createStub(
+      AccountWrapper.class, 
+      new AccountWrapperMock()
+    );
+    OpportunityDiscount od = new OpportunityDiscount(mockAccountWrapper);
+    // WHEN
+    Test.startTest();
+      Decimal result = od.getTotalDiscount();
+    Test.stopTest();
+    // THEN
+    Assert.areEqual(.25, result, 'Expected to get .25');
+  }
+}

--- a/Advanced Apex Testing/force-app/main/default/classes/OpportunityDiscountTests.cls-meta.xml
+++ b/Advanced Apex Testing/force-app/main/default/classes/OpportunityDiscountTests.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>59.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
Reviewed Mocks which are used for testing HTTP callouts as well as an introduction to Stub Objects.

Stub Objects are used in testing when your test depends on other operations within the platform. 